### PR TITLE
[AMRFinderPlus] Adding AMRFinderPlus

### DIFF
--- a/modules/local/gene_typing/drug_resistance/amrfinderplus/main.nf
+++ b/modules/local/gene_typing/drug_resistance/amrfinderplus/main.nf
@@ -1,0 +1,241 @@
+process AMRFINDER_PLUS_NUC {
+    tag "${meta.id}"
+    label 'process_low'
+
+    container "us-docker.pkg.dev/general-theiagen/staphb/ncbi-amrfinderplus:4.0.23-2025-06-03.1"
+
+    input:
+    tuple val(meta), path(assembly)
+    val organism
+    output:
+    tuple val(meta), path("*_amrfinder_all.tsv"), emit: amrfinderplus_all_report
+    tuple val(meta), path("*_amrfinder_amr.tsv"), emit: amrfinderplus_amr_report
+    tuple val(meta), path("*_amrfinder_stress.tsv"), emit: amrfinderplus_stress_report
+    tuple val(meta), path("*_amrfinder_virulence.tsv"), emit: amrfinderplus_virulence_report
+    tuple val(meta), path("AMR_CORE_GENES"), emit: amrfinderplus_amr_core_genes
+    tuple val(meta), path("AMR_PLUS_GENES"), emit: amrfinderplus_amr_plus_genes
+    tuple val(meta), path("STRESS_GENES"), emit: amrfinderplus_stress_genes
+    tuple val(meta), path("VIRULENCE_GENES"), emit: amrfinderplus_virulence_genes
+    tuple val(meta), path("AMR_CLASSES"), emit: amrfinderplus_amr_classes
+    tuple val(meta), path("AMR_SUBCLASSES"), emit: amrfinderplus_amr_subclasses
+    tuple val(meta), path("BETA_LACTAM_GENES"), emit: amrfinderplus_amr_betalactam_genes
+    tuple val(meta), path("BETA_LACTAM_BETA_LACTAM_GENES"), emit: amrfinderplus_amr_betalactam_betalactam_genes
+    tuple val(meta), path("BETA_LACTAM_CARBAPENEM_GENES"), emit: amrfinderplus_amr_betalactam_carbapenem_genes
+    tuple val(meta), path("BETA_LACTAM_CEPHALOSPORIN_GENES"), emit: amrfinderplus_amr_betalactam_cephalosporin_genes
+    tuple val(meta), path("BETA_LACTAM_CEPHALOTHIN_GENES"), emit: amrfinderplus_amr_betalactam_cephalothin_genes
+    tuple val(meta), path("BETA_LACTAM_METHICILLIN_GENES"), emit: amrfinderplus_amr_betalactam_methicillin_genes
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def organism_arg = organism ? "--organism ${organism}" : ""
+    def min_percent_identity_arg = params.amrfinder_min_percent_identity ? "--ident_min $params.amrfinder_min_percent_identity" : ""
+    def min_percent_coverage_arg = params.amrfinder_min_percent_coverage ? "--coverage_min $params.amrfinder_min_percent_coverage" : ""
+    def hide_point_mutations = params.amrfinder_hide_point_mutations ?: false
+    def detailed_drug_class = params.amrfinder_detailed_drug_class ?: false
+    def separate_betalactam_genes = params.amrfinder_separate_betalactam_genes ?: false
+
+    """
+    # logging info
+    date | tee DATE
+
+    # Initialize variable to avoid unbound variable error
+    amrfinder_organism=""
+
+    ## create associative array
+    declare -A organisms=( ["Acinetobacter baumannii"]="Acinetobacter_baumannii" ["Burkholderia cepacia"]="Burkholderia_cepacia" \\
+      ["Burkholderia pseudomallei"]="Burkholderia_pseudomallei" ["Campylobacter coli"]="Campylobacter" ["Campylobacter jejuni"]="Campylobacter" \\
+      ["Citrobacter freundii"]="Citrobacter_freundii" ["Clostridioides difficile"]="Clostridioides_difficile" ["Enterobacter asburiae"]="Enterobacter_asburiae" ["Enterobacter cloacae"]="Enterobacter_cloacae" \\
+      ["Enterococcus faecalis"]="Enterococcus_faecalis" ["Enterococcus hirae"]="Enterococcus_faecium" ["Enterococcusfaecium"]="Enterococcus_faecium" \\
+      ["Escherichia"]="Escherichia" ["Shigella"]="Escherichia" ["Klebsiella aerogenes"]="Klebsiella_pneumoniae" ["Klebsiella pneumoniae"]="Klebsiella_pneumoniae" \\
+      ["Klebsiella variicola"]="Klebsiella_pneumoniae" ["Klebsiella oxytoca"]="Klebsiella_oxytoca" ["Neisseria gonorrhea"]="Neisseria_gonorrhoeae" \\
+      ["Neisseria gonorrhoeae"]="Neisseria_gonorrhoeae" ["Neisseria meningitidis"]="Neisseria_meningitidis" ["Pseudomonas aeruginosa"]="Pseudomonas_aeruginosa" \\
+      ["Salmonella"]="Salmonella" ["Serratia marcescens"]="Serratia_marcescens" ["Staphylococcus aureus"]="Staphylococcus_aureus" \\
+      ["Staphylococcus pseudintermedius"]="Staphylococcus_pseudintermedius" ["Streptococcus agalactiae"]="Streptococcus_agalactiae" \\
+      ["Streptococcus pneumoniae"]="Streptococcus_pneumoniae" ["Streptococcus mitis"]="Streptococcus_pneumoniae" \\
+      ["Streptococcus pyogenes"]="Streptococcus_pyogenes" ["Vibrio cholerae"]="Vibrio_cholerae" ["Vibrio parahaemolyticus"]="Vibrio_parahaemolyticus" ["Vibrio vulnificus"]="Vibrio_vulnificus"
+      )
+
+    for key in "\${!organisms[@]}"; do
+      if [[ "${organism}" == \$key ]]; then
+        amrfinder_organism=\${organisms[\$key]}
+      elif [[ "${organism}" == *\$key* ]]; then
+        amrfinder_organism=\${organisms[\$key]}
+      fi
+    done
+
+    # checking bash variable
+    echo "amrfinder_organism is set to: \${amrfinder_organism}"
+    
+    # if amrfinder_organism variable has a value, use --organism flag, otherwise do not use --organism flag
+    if [[ -n "\${amrfinder_organism}" ]] ; then
+      # always use --plus flag, others may be left out if param is optional and not supplied 
+      amrfinder --plus \\
+        ${organism_arg} \\
+        --name ${prefix} \\
+        --nucleotide ${assembly} \\
+        -o ${prefix}_amrfinder_all.tsv \\
+        ${'--threads ' + task.cpus} \\
+        ${min_percent_coverage_arg} \\
+        ${min_percent_identity_arg} \\
+        ${args}
+    else 
+      echo "Either the organism (${organism}) is not recognized by NCBI-AMRFinderPlus or the user did not supply an organism as input."
+      echo "Skipping the use of amrfinder --organism optional parameter."
+      # always use --plus flag, others may be left out if param is optional and not supplied 
+      amrfinder --plus \\
+        --name ${prefix} \\
+        --nucleotide ${assembly} \\
+        -o ${prefix}_amrfinder_all.tsv \\
+        ${'--threads ' + task.cpus} \\
+        ${min_percent_coverage_arg} \\
+        ${min_percent_identity_arg} \\
+        ${args}
+    fi
+
+    echo "removing mutations"
+    # remove mutations where Element subtype is "POINT"
+    if [[ ${hide_point_mutations} == "true" ]]; then
+      awk -F "\t" '\$11 != "POINT"' ${prefix}_amrfinder_all.tsv >> temp.tsv
+      mv temp.tsv ${prefix}_amrfinder_all.tsv
+    fi
+    echo "removed mutations"
+
+    # Element Type possibilities: AMR, STRESS, and VIRULENCE 
+    # create headers for 3 output files; tee to 3 files and redirect STDOUT to dev null so it doesn't print to log file
+    head -n 1 ${prefix}_amrfinder_all.tsv | tee ${prefix}_amrfinder_stress.tsv ${prefix}_amrfinder_virulence.tsv ${prefix}_amrfinder_amr.tsv >/dev/null
+    # looks for all rows with STRESS, AMR, or VIRULENCE and append to TSVs
+    # || true is so that the final grep exits with code 0, preventing failures
+    grep 'STRESS' ${prefix}_amrfinder_all.tsv >> ${prefix}_amrfinder_stress.tsv || true
+    grep 'VIRULENCE' ${prefix}_amrfinder_all.tsv >> ${prefix}_amrfinder_virulence.tsv || true
+    grep 'AMR' ${prefix}_amrfinder_all.tsv >> ${prefix}_amrfinder_amr.tsv || true
+    echo "separated AMR, STRESS, and VIRULENCE genes"
+
+    # create string outputs for all genes identified in AMR, STRESS, VIRULENCE
+    amr_core_genes=\$(awk -F '\\t' '{ if(\$9 == "core") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tr '\\n' ', ' | sed 's/.\$//')
+    amr_plus_genes=\$(awk -F '\\t' '{ if(\$9 != "core") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tail -n+2 | tr '\\n' ', ' | sed 's/.\$//')
+    stress_genes=\$(awk -F '\\t' '{ print \$7 }' ${prefix}_amrfinder_stress.tsv | tail -n+2 | tr '\\n' ', ' | sed 's/.\$//')
+    virulence_genes=\$(awk -F '\\t' '{ print \$7 }' ${prefix}_amrfinder_virulence.tsv | tail -n+2 | tr '\\n' ', ' | sed 's/.\$//')
+    
+    echo "separating AMR classes and subclasses"
+    if [[ ${detailed_drug_class} == "true" ]]; then
+      # create string outputs for AMR drug classes
+      amr_classes=\$(awk -F '\\t' 'BEGIN{OFS=":"} {print \$7,\$12}' ${prefix}_amrfinder_amr.tsv | tail -n+2 | tr '\\n' ', ' | sed 's/.\$//')
+      # create string outputs for AMR drug subclasses
+      amr_subclasses=\$(awk -F '\\t' 'BEGIN{OFS=":"} {print \$7,\$13}' ${prefix}_amrfinder_amr.tsv | tail -n+2 | tr '\\n' ', ' | sed 's/.\$//')
+    else
+      amr_classes=\$(awk -F '\\t' '{ print \$12 }' ${prefix}_amrfinder_amr.tsv | tail -n+2 | sort | uniq | tr '\\n' ', ' | sed 's/.\$//')
+      amr_subclasses=\$(awk -F '\\t' '{ print \$13 }' ${prefix}_amrfinder_amr.tsv | tail -n+2 | sort | uniq | tr '\\n' ', ' | sed 's/.\$//')
+    fi
+
+    echo "separating genes"
+    if [[ ${separate_betalactam_genes} == "true" ]]; then
+      betalactam_genes=\$(awk -F '\\t' '{ if(\$12 == "BETA-LACTAM") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tr '\\n' ', ' | sed 's/.\$//') 
+      betalactam_betalactam_genes=\$(awk -F '\\t' '{ if(\$13 == "BETA-LACTAM") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tr '\\n' ', ' | sed 's/.\$//') 
+      betalactam_carbapenem_genes=\$(awk -F '\\t' '{ if(\$13 == "CARBAPENEM") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tr '\\n' ', ' | sed 's/.\$//')
+      betalactam_cephalosporin_genes=\$(awk -F '\\t' '{ if(\$13 == "CEPHALOSPORIN") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tr '\\n' ', ' | sed 's/.\$//')
+      betalactam_cephalothin_genes=\$(awk -F '\\t' '{ if(\$13 == "CEPHALOTHIN") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tr '\\n' ', ' | sed 's/.\$//')
+      betalactam_methicillin_genes=\$(awk -F '\\t' '{ if(\$13 == "METHICILLIN") { print \$7}}' ${prefix}_amrfinder_amr.tsv | tr '\\n' ', ' | sed 's/.\$//')
+      
+      # if variable for list of genes is EMPTY, write string saying it is empty to float to Terra table
+      if [ -z "\${betalactam_genes}" ]; then
+        betalactam_genes="No BETA-LACTAM genes detected by NCBI-AMRFinderPlus"
+      fi
+      if [ -z "\${betalactam_betalactam_genes}" ]; then
+        betalactam_betalactam_genes="No BETA-LACTAM genes detected by NCBI-AMRFinderPlus"
+      fi
+      if [ -z "\${betalactam_carbapenem_genes}" ]; then
+        betalactam_carbapenem_genes="No BETA-LACTAM CARBAPENEM genes detected by NCBI-AMRFinderPlus"
+      fi
+      if [ -z "\${betalactam_cephalosporin_genes}" ]; then
+        betalactam_cephalosporin_genes="No BETA-LACTAM CEPHALOSPORIN genes detected by NCBI-AMRFinderPlus"
+      fi
+      if [ -z "\${betalactam_cephalothin_genes}" ]; then
+        betalactam_cephalothin_genes="No BETA-LACTAM CEPHALOTHIN genes detected by NCBI-AMRFinderPlus"
+      fi
+      if [ -z "\${betalactam_methicillin_genes}" ]; then
+        betalactam_methicillin_genes="No BETA-LACTAM METHICILLIN genes detected by NCBI-AMRFinderPlus"
+      fi
+    else 
+        betalactam_genes=""
+        betalactam_betalactam_genes=""
+        betalactam_carbapenem_genes=""
+        betalactam_cephalosporin_genes=""
+        betalactam_cephalothin_genes=""
+        betalactam_methicillin_genes=""
+    fi
+
+    # if variable for list of genes is EMPTY, write string saying it is empty to float to Terra table
+    if [ -z "\${amr_core_genes}" ]; then
+       amr_core_genes="No core AMR genes detected by NCBI-AMRFinderPlus"
+    fi 
+    if [ -z "\${amr_plus_genes}" ]; then
+       amr_plus_genes="No plus AMR genes detected by NCBI-AMRFinderPlus"
+    fi 
+    if [ -z "\${stress_genes}" ]; then
+       stress_genes="No STRESS genes detected by NCBI-AMRFinderPlus"
+    fi 
+    if [ -z "\${virulence_genes}" ]; then
+       virulence_genes="No VIRULENCE genes detected by NCBI-AMRFinderPlus"
+    fi 
+    if [ -z "\${amr_classes}" ]; then
+       amr_classes="No AMR genes detected by NCBI-AMRFinderPlus"
+    fi 
+    if [ -z "\${amr_subclasses}" ]; then
+       amr_subclasses="No AMR genes detected by NCBI-AMRFinderPlus"
+    fi 
+
+    # create final output strings
+    echo "\${amr_core_genes}" > AMR_CORE_GENES
+    echo "\${amr_plus_genes}" > AMR_PLUS_GENES
+    echo "\${stress_genes}" > STRESS_GENES
+    echo "\${virulence_genes}" > VIRULENCE_GENES
+    echo "\${amr_classes}" > AMR_CLASSES
+    echo "\${amr_subclasses}" > AMR_SUBCLASSES
+  
+    # if separate_betalactam_genes is true, create final output strings (if false, these values will be blank)
+    echo "\${betalactam_genes}" > BETA_LACTAM_GENES
+    echo "\${betalactam_betalactam_genes}" > BETA_LACTAM_BETA_LACTAM_GENES
+    echo "\${betalactam_carbapenem_genes}" > BETA_LACTAM_CARBAPENEM_GENES
+    echo "\${betalactam_cephalosporin_genes}" > BETA_LACTAM_CEPHALOSPORIN_GENES
+    echo "\${betalactam_cephalothin_genes}" > BETA_LACTAM_CEPHALOTHIN_GENES
+    echo "\${betalactam_methicillin_genes}" > BETA_LACTAM_METHICILLIN_GENES
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        amrfinderplus: \$(amrfinder --version)
+        amrfinderplus-database: \$(echo \$(amrfinder --database amrfinderdb --database_version 2> stdout) | rev | cut -f 1 -d ' ' | rev)
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "na" > "${prefix}_amrfinder_all.tsv"
+    echo "na" > "${prefix}_amrfinder_amr.tsv"
+    echo "na" > "${prefix}_amrfinder_stress.tsv"
+    echo "na" > "${prefix}_amrfinder_virulence.tsv"
+    echo "na" > AMR_CORE_GENES
+    echo "na" > AMR_PLUS_GENES
+    echo "na" > STRESS_GENES
+    echo "na" > VIRULENCE_GENES
+    echo "na" > AMR_CLASSES
+    echo "na" > AMR_SUBCLASSES
+    echo "na" > BETA_LACTAM_GENES
+    echo "na" > BETA_LACTAM_BETA_LACTAM_GENES
+    echo "na" > BETA_LACTAM_CARBAPENEM_GENES
+    echo "na" > BETA_LACTAM_CEPHALOSPORIN_GENES
+    echo "na" > BETA_LACTAM_CEPHALOTHIN_GENES
+    echo "na" > BETA_LACTAM_METHICILLIN_GENES
+    
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        amrfinderplus: \$(amrfinder --version)
+        amrfinderplus-database: \$(echo \$(amrfinder --database amrfinderdb --database_version 2> stdout) | rev | cut -f 1 -d ' ' | rev)
+    END_VERSIONS
+    """
+}

--- a/modules/local/gene_typing/drug_resistance/amrfinderplus/tests/main.nf.test
+++ b/modules/local/gene_typing/drug_resistance/amrfinderplus/tests/main.nf.test
@@ -1,0 +1,78 @@
+nextflow_process {
+    name "Test Process AMRFINDER_PLUS_NUC"
+    script "../main.nf"
+    process "AMRFINDER_PLUS_NUC"
+    
+    test("amrfinderplus test") {
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_sample' ],
+                    file(params.pipelines_testdata_base_path + "genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz", checkIfExists: true)
+                ])
+                input[1] = "Bacteroides fragilis"
+                
+                // Override process parameters for this test
+                params.amrfinder_min_percent_identity = 90
+                params.amrfinder_min_percent_coverage = 80
+                params.amrfinder_hide_point_mutations = true
+                params.amrfinder_detailed_drug_class = true
+                params.amrfinder_separate_betalactam_genes = true
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.amrfinderplus_all_report,
+                    process.out.amrfinderplus_amr_report,
+                    process.out.amrfinderplus_stress_report,
+                    process.out.amrfinderplus_virulence_report,
+                    process.out.amrfinderplus_amr_core_genes,
+                    process.out.amrfinderplus_amr_plus_genes,
+                    process.out.amrfinderplus_stress_genes,
+                    process.out.amrfinderplus_virulence_genes,
+                    process.out.amrfinderplus_amr_classes,
+                    process.out.amrfinderplus_amr_subclasses,
+                    process.out.amrfinderplus_amr_betalactam_genes,
+                    process.out.amrfinderplus_amr_betalactam_betalactam_genes,
+                    process.out.amrfinderplus_amr_betalactam_carbapenem_genes,
+                    process.out.amrfinderplus_amr_betalactam_cephalosporin_genes,
+                    process.out.amrfinderplus_amr_betalactam_cephalothin_genes,
+                    process.out.amrfinderplus_amr_betalactam_methicillin_genes,
+                    process.out.versions
+                    ).match() }
+            )
+        }
+    }
+    
+    test("amrfinderplus - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_sample' ],
+                    file(params.pipelines_testdata_base_path + "genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz", checkIfExists: true)
+                ])
+                input[1] = "Bacteroides fragilis"
+                
+                // Override process parameters for this test
+                params.amrfinder_min_percent_identity = 90
+                params.amrfinder_min_percent_coverage = 80
+                params.amrfinder_hide_point_mutations = true
+                params.amrfinder_detailed_drug_class = true
+                params.amrfinder_separate_betalactam_genes = true
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/local/gene_typing/drug_resistance/amrfinderplus/tests/main.nf.test.snap
+++ b/modules/local/gene_typing/drug_resistance/amrfinderplus/tests/main.nf.test.snap
@@ -1,0 +1,415 @@
+{
+    "amrfinderplus - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_all.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_amr.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "10": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "11": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_BETA_LACTAM_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "12": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_CARBAPENEM_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "13": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_CEPHALOSPORIN_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "14": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_CEPHALOTHIN_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "15": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_METHICILLIN_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "16": [
+                    "versions.yml:md5,df77fcefb7d9d4d7ac2a0fb46a102fba"
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_stress.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_virulence.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_CORE_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_PLUS_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "STRESS_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "VIRULENCE_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_CLASSES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "9": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_SUBCLASSES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_all_report": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_all.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_betalactam_betalactam_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_BETA_LACTAM_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_betalactam_carbapenem_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_CARBAPENEM_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_betalactam_cephalosporin_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_CEPHALOSPORIN_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_betalactam_cephalothin_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_CEPHALOTHIN_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_betalactam_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_betalactam_methicillin_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "BETA_LACTAM_METHICILLIN_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_classes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_CLASSES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_core_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_CORE_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_plus_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_PLUS_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_report": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_amr.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_amr_subclasses": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "AMR_SUBCLASSES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_stress_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "STRESS_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_stress_report": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_stress.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_virulence_genes": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "VIRULENCE_GENES:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "amrfinderplus_virulence_report": [
+                    [
+                        {
+                            "id": "test_sample"
+                        },
+                        "test_sample_amrfinder_virulence.tsv:md5,51bb9b62d9be48ac08dfb0ec931632e2"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,df77fcefb7d9d4d7ac2a0fb46a102fba"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.8"
+        },
+        "timestamp": "2025-06-24T16:33:19.415848086"
+    },
+    "amrfinderplus test": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_amrfinder_all.tsv:md5,5d149a99b3d4a97aad6e6fc9811a99c0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_amrfinder_amr.tsv:md5,5d149a99b3d4a97aad6e6fc9811a99c0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_amrfinder_stress.tsv:md5,376a8991c8eb010ea64c796115fb9b8d"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_amrfinder_virulence.tsv:md5,376a8991c8eb010ea64c796115fb9b8d"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "AMR_CORE_GENES:md5,6991e40bc4b82e9e61d66ac6056838c0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "AMR_PLUS_GENES:md5,c36903f7be16a68f69470cb6f48b277a"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "STRESS_GENES:md5,4bd51f5d569c0eafb786b26558921e3a"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "VIRULENCE_GENES:md5,9c9c511ab5bfade46f0db1b2ee5b4666"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "AMR_CLASSES:md5,0d62cf49674cd328e1821ea1e13333ab"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "AMR_SUBCLASSES:md5,48e15125b04e565680ab379326db80b9"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "BETA_LACTAM_GENES:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "BETA_LACTAM_BETA_LACTAM_GENES:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "BETA_LACTAM_CARBAPENEM_GENES:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "BETA_LACTAM_CEPHALOSPORIN_GENES:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "BETA_LACTAM_CEPHALOTHIN_GENES:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "BETA_LACTAM_METHICILLIN_GENES:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                "versions.yml:md5,df77fcefb7d9d4d7ac2a0fb46a102fba"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.8"
+        },
+        "timestamp": "2025-06-24T16:33:14.106069411"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,6 +55,12 @@ params {
     filter_contigs_skip_length_filter     = false
     filter_contigs_skip_coverage_filter   = false
     filter_contigs_skip_homopolymer_filter = false
+    // AMRFinderPlus Options
+    amrfinder_min_percent_identity = null
+    amrfinder_min_percent_coverage = null
+    amrfinder_detailed_drug_class = false
+    amrfinder_hide_point_mutations = false
+    amrfinder_separate_betalactam_genes = false
     // Boilerplate options
     outdir                       = null
     publish_dir_mode             = 'copy'


### PR DESCRIPTION
Some logic changed around, `|| true` added to all `grep` of STRESS, VIRULENCE, and AMR genes as a quick fix due to throwing errors when nothing was found. Adding `betalactam_genes` declaration due to unbound variable being thrown. 