### PR TITLE
Update mock test data for poppunk

### DIFF
--- a/modules/local/species_typing/streptococcus/poppunk/run/main.nf
+++ b/modules/local/species_typing/streptococcus/poppunk/run/main.nf
@@ -2,7 +2,8 @@ process POPPUNK {
     tag "$meta.id"
     label "process_medium"
 
-    container "us-docker.pkg.dev/general-theiagen/staphb/poppunk:2.4.0"
+    // container "us-docker.pkg.dev/general-theiagen/staphb/poppunk:2.4.0"
+    container 'community.wave.seqera.io/library/poppunk:2.4.0--e909346af4c3d6fe'
 
     input:
     tuple val(meta), path(assembly)
@@ -30,7 +31,7 @@ process POPPUNK {
     
     # Determine the database name
     GPS_DB_NAME=\$(grep "^Database:" ${gps_db_info} | cut -d' ' -f2)
-    echo "\${GPS_DB_NAME}"
+    echo "\${GPS_DB_NAME}" > GPS_DB_NAME
 
     # Run poppunk
     poppunk_assign \\
@@ -48,10 +49,10 @@ process POPPUNK {
         
         # If GPSC is "NA", overwrite with helpful message
         if [[ "\$(cat GPSC.txt)" == "NA" ]]; then
-            echo "Potential novel GPS Cluster identified, please email globalpneumoseq@gmail.com to have novel clusters added to the database and a GPSC cluster name assigned after you have checked for low level contamination which may contribute to biased accessory distances." > GPSC.txt
+            echo "Potential novel GPS Cluster identified, please email globalpneumoseq@gmail.com to have novel clusters added to the database and a GPSC cluster name assigned after you have checked for low level contamination which may contribute to biased accessory distances." >> GPSC.txt
         fi
     else
-        echo "poppunk failed" > GPSC.txt
+        echo "poppunk failed" >> GPSC.txt
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/species_typing/streptococcus/poppunk/run/test/main.nf.test
+++ b/modules/local/species_typing/streptococcus/poppunk/run/test/main.nf.test
@@ -11,10 +11,16 @@ nextflow_process {
                 script "../../fetch/main.nf"
                 process {
                     """
-                    input[0] = "https://gps-project.cog.sanger.ac.uk/GPS_v9.tar.gz"
-                    input[1] = "https://gps-project.cog.sanger.ac.uk/GPS_v9_external_clusters.csv"
+                    input[0] = "https://raw.githubusercontent.com/theiagen/test-datasets/poppunk/data/strep.tar.gz"
+                    input[1] = "https://raw.githubusercontent.com/theiagen/test-datasets/poppunk/data/GPS_v9_external_clusters.csv"
                     """
                 }
+                // process {
+                //     """
+                //     input[0] = "https://gps-project.cog.sanger.ac.uk/GPS_v9.tar.gz"
+                //     input[1] = "https://gps-project.cog.sanger.ac.uk/GPS_v9_external_clusters.csv"
+                //     """
+                // }
             }
             
             run("GUNZIP") {
@@ -34,7 +40,7 @@ nextflow_process {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = POPPUNK_DATABASE.out.database
-                input[2] = POPPUNK_DATABASE.out.ext_clusters
+                input[2] = "https://raw.githubusercontent.com/theiagen/test-datasets/poppunk/data/GPS_v9_external_clusters.csv"
                 input[3] = POPPUNK_DATABASE.out.db_info
                 """
             }
@@ -58,8 +64,8 @@ nextflow_process {
                 script "../../fetch/main.nf"
                 process {
                     """
-                    input[0] = "https://gps-project.cog.sanger.ac.uk/GPS_v9.tar.gz"
-                    input[1] = "https://gps-project.cog.sanger.ac.uk/GPS_v9_external_clusters.csv"
+                    input[0] = "https://raw.githubusercontent.com/theiagen/test-datasets/poppunk/data/strep.tar.gz"
+                    input[1] = "https://raw.githubusercontent.com/theiagen/test-datasets/poppunk/data/GPS_v9_external_clusters.csv"
                     """
                 }
             }

--- a/modules/local/species_typing/streptococcus/poppunk/run/test/main.nf.test.snap
+++ b/modules/local/species_typing/streptococcus/poppunk/run/test/main.nf.test.snap
@@ -62,24 +62,34 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.4"
         },
-        "timestamp": "2025-06-25T18:39:55.889800257"
+        "timestamp": "2025-06-29T12:23:49.95581034"
     },
     "POPPUNK - test": {
         "content": [
             [
-                
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "GPSC.txt:md5,0f3dde9cbeb30baa9ebb6b19367535a2"
+                ]
             ],
             [
-                
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "GPS_DB_NAME:md5,714d311914f0130572e8f9d0a42be9ce"
+                ]
             ],
             [
-                
+                "versions.yml:md5,531092b9c7ba01c441ff748497effa7a"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.4"
         },
-        "timestamp": "2025-06-25T18:39:41.514434383"
+        "timestamp": "2025-06-29T12:23:38.435583054"
     }
 }


### PR DESCRIPTION
- Updated mock test data with smaller size of 100 *Strep pneumonia* genomes by GTDB -> ~ 15MB
- Used docker image with the same poppunk version 2.4.0 built via seqera container service but newer scikit-learn version, as this dep affects to the database type