### PR TITLE
fix: disabled entrypoint for the docker & made input data as ascii input

### DIFF
--- a/modules/local/gene_typing/drug_resistance/amr_search/test/main.nf.test.snap
+++ b/modules/local/gene_typing/drug_resistance/amr_search/test/main.nf.test.snap
@@ -2,22 +2,37 @@
     "amr search test": {
         "content": [
             [
-                
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_amr_results.csv:md5,c2ddc073d73f04f6a84eeb640ea7ceb7"
+                ]
             ],
             [
-                
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_amr_results.pdf:md5,43e4ff7992d7e476ce14c899b7c4b246"
+                ]
             ],
             [
-                
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_paarsnp_results.json:md5,951a50fb36342194c7035bc6fff6f714"
+                ]
             ],
             [
-                
+                "versions.yml:md5,fe8225ce22a17692b1c55e4e6165dde4"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.4"
         },
-        "timestamp": "2025-06-18T13:50:59.534676745"
+        "timestamp": "2025-06-30T15:55:09.519685265"
     }
 }


### PR DESCRIPTION
- The docker image had entrypoint as an amr_search command so need to disable this for running with NF
- Decompress the input sequence file if compressed (gz, gzip) as amr_search requires plain text/ ascii input